### PR TITLE
chore: bump io.unico:capture to v5.43.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation "io.unico:capture:5.38.0"
+io.unico:capture:5.43.0
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'


### PR DESCRIPTION

        ### 🚀 Automatic Update
        Bumps `io.unico:capture` from `5.38.0` to version **5.43.0**.
        
        - 📅 **Release date**: 02/09/2025
        - 🔗 **Official Release Notes**: [https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-android/release-notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-android/release-notes)
        