### PR TITLE
Update capture to v5.44.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation "io.unico:capture:5.42.0"
+    implementation "io.unico:capture:5.44.0"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'


### PR DESCRIPTION

    Automatic update of `io.unico:capture` to version **5.44.0** 📅 Release date: **16/09/2025** 🔗 [Official Release Notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-android/release-notes)
    